### PR TITLE
fix(web): repair navbar search layout, jobs error rendering, and facet labels

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -83,7 +83,7 @@ export function TopBar() {
           aria-label="Open menu"
           aria-expanded={mobileNavOpen}
           aria-controls="mobile-primary-nav"
-          className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-ink-muted hover:text-ink md:hidden"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-ink-muted hover:text-ink lg:hidden"
         >
           <Menu className="h-4 w-4" />
         </button>
@@ -103,7 +103,12 @@ export function TopBar() {
           </span>
         </Link>
 
-        <nav aria-label="Primary" className="hidden items-center gap-1 md:flex">
+        {/*
+          lg, not md: the six primary links measure ~420px, which together with
+          the logo and the action cluster overran the 768px row and scrolled the
+          whole page sideways. Below lg they live in the hamburger sheet.
+        */}
+        <nav aria-label="Primary" className="hidden items-center gap-1 lg:flex">
           {SHELL_PRIMARY_NAV.map((item) => {
             const active = shellNavItemActive(pathname, item.to);
             return (
@@ -134,9 +139,24 @@ export function TopBar() {
           })}
         </nav>
 
-        <div className="ml-auto flex flex-1 items-center justify-end gap-2 md:max-w-md">
+        {/*
+          No min-w-0 here on purpose: the cluster must keep its intrinsic width
+          so the icon buttons and Submit CTA never collapse into each other.
+          Only the search slot inside it is allowed to shrink.
+        */}
+        <div className="ml-auto flex flex-1 items-center justify-end gap-2">
           {!isHome && (
-            <div className="hidden flex-1 sm:block">
+            // Capped on the search itself rather than on the whole right cluster:
+            // a cluster-wide cap left the input (and its dropdown, which tracks
+            // the input's width) around 200px, crushing the scope chips and
+            // truncating result titles.
+            //
+            // On from sm (nav is in the hamburger, so the row is free), off at
+            // lg where the ~420px nav appears and leaves too little for a usable
+            // input, back on at xl where nav + search + actions all fit. Forcing
+            // an input into the lg band pushed the action buttons past the row
+            // and scrolled the whole page sideways.
+            <div className="hidden min-w-0 flex-1 sm:block lg:hidden xl:block xl:max-w-md">
               <CommandBar size="md" showHint={false} />
             </div>
           )}

--- a/apps/web/src/components/command-bar.tsx
+++ b/apps/web/src/components/command-bar.tsx
@@ -323,7 +323,9 @@ export function CommandBar({
           }}
           placeholder={`Search Claude workflows — try "${EXAMPLES[placeholderIdx]}"`}
           className={cn(
-            "flex-1 bg-transparent text-ink placeholder:text-ink-subtle focus:outline-none",
+            // min-w-0: an <input> carries a default intrinsic width (~200px), so
+            // without this the header row cannot shrink below it and overflows.
+            "min-w-0 flex-1 bg-transparent text-ink placeholder:text-ink-subtle focus:outline-none",
             size === "lg" ? "text-base" : "text-sm",
           )}
         />
@@ -342,7 +344,11 @@ export function CommandBar({
       </span>
 
       {showPanel && (
-        <div className="absolute left-0 right-0 top-full z-50 mt-2 overflow-hidden rounded-xl border border-border bg-surface shadow-lg">
+        // Anchored to the input's right edge and sized independently of it:
+        // `min-w-full` keeps the panel flush with a wide input (home hero),
+        // while the fixed width lets it grow leftward out of a narrow one
+        // (header) instead of inheriting a ~200px column.
+        <div className="absolute right-0 top-full z-50 mt-2 w-[min(34rem,calc(100vw-2rem))] min-w-full overflow-hidden rounded-xl border border-border bg-surface shadow-lg">
           <div className="flex flex-wrap items-center gap-1.5 border-b border-border bg-surface-2 px-3 py-2">
             <span className="eyebrow mr-1">Scope</span>
             {[
@@ -382,11 +388,16 @@ export function CommandBar({
             ))}
           </div>
 
+          {/*
+            overflow-x-hidden is load-bearing: with only `overflow-y-auto`, CSS
+            computes the x axis to `auto` too, so any over-wide row silently
+            turns the list into a horizontal scroller.
+          */}
           <ul
             id={listboxId}
             role="listbox"
             aria-label="Search results and actions"
-            className="max-h-96 overflow-y-auto py-1"
+            className="max-h-96 overflow-y-auto overflow-x-hidden py-1"
           >
             {results.length > 0 && (
               <li
@@ -420,21 +431,21 @@ export function CommandBar({
                       active === i && "bg-surface-2",
                     )}
                   >
-                    <div className="flex items-center gap-3">
-                      <CategoryPill>{r.category}</CategoryPill>
-                      <span className="truncate font-medium text-ink">{r.title}</span>
-                      <TrustBadge level={r.trust} />
+                    <div className="flex min-w-0 items-center gap-2">
+                      <CategoryPill className="shrink-0">{r.category}</CategoryPill>
+                      <span className="min-w-0 flex-1 truncate font-medium text-ink">{r.title}</span>
+                      <TrustBadge level={r.trust} className="shrink-0" />
                     </div>
-                    <div className="flex items-center gap-3 pl-1 text-[11px] text-ink-muted">
-                      <span className="line-clamp-1 flex-1">{r.description}</span>
+                    <div className="flex min-w-0 items-center gap-2 pl-1 text-[11px] text-ink-muted">
+                      <span className="line-clamp-1 min-w-0 flex-1">{r.description}</span>
                       {installable && (
-                        <span className="inline-flex items-center gap-1" title="Installable">
+                        <span className="inline-flex shrink-0 items-center gap-1" title="Installable">
                           <TerminalSquare className="h-3 w-3" aria-hidden /> install
                         </span>
                       )}
                       <span
                         className={cn(
-                          "inline-flex items-center gap-1",
+                          "inline-flex shrink-0 items-center gap-1",
                           hasSafety ? "text-ink-muted" : "text-ink-subtle",
                         )}
                         title={hasSafety ? "Safety notes present" : "No safety notes"}
@@ -443,7 +454,7 @@ export function CommandBar({
                       </span>
                       <span
                         className={cn(
-                          "inline-flex items-center gap-1",
+                          "inline-flex shrink-0 items-center gap-1",
                           hasPrivacy ? "text-ink-muted" : "text-ink-subtle",
                         )}
                         title={hasPrivacy ? "Privacy notes present" : "No privacy notes"}
@@ -452,7 +463,7 @@ export function CommandBar({
                       </span>
                       {stars !== null && (
                         <span
-                          className="inline-flex items-center gap-1 tabular-nums"
+                          className="inline-flex shrink-0 items-center gap-1 tabular-nums"
                           title={`${stars.toLocaleString()} source repository stars`}
                         >
                           <Star className="h-3 w-3" aria-hidden />

--- a/apps/web/src/components/command-bar.tsx
+++ b/apps/web/src/components/command-bar.tsx
@@ -433,13 +433,18 @@ export function CommandBar({
                   >
                     <div className="flex min-w-0 items-center gap-2">
                       <CategoryPill className="shrink-0">{r.category}</CategoryPill>
-                      <span className="min-w-0 flex-1 truncate font-medium text-ink">{r.title}</span>
+                      <span className="min-w-0 flex-1 truncate font-medium text-ink">
+                        {r.title}
+                      </span>
                       <TrustBadge level={r.trust} className="shrink-0" />
                     </div>
                     <div className="flex min-w-0 items-center gap-2 pl-1 text-[11px] text-ink-muted">
                       <span className="line-clamp-1 min-w-0 flex-1">{r.description}</span>
                       {installable && (
-                        <span className="inline-flex shrink-0 items-center gap-1" title="Installable">
+                        <span
+                          className="inline-flex shrink-0 items-center gap-1"
+                          title="Installable"
+                        >
                           <TerminalSquare className="h-3 w-3" aria-hidden /> install
                         </span>
                       )}

--- a/apps/web/src/components/filter-chip.tsx
+++ b/apps/web/src/components/filter-chip.tsx
@@ -16,6 +16,7 @@ export function FilterChip({
   size = "sm",
   count,
   disabled,
+  preserveCase = false,
 }: {
   active: boolean;
   onClick: () => void;
@@ -26,6 +27,12 @@ export function FilterChip({
   count?: number;
   /** Visually de-emphasize without removing from tab order. */
   disabled?: boolean;
+  /**
+   * Opt out of the default `capitalize`. Set when the caller already supplies a
+   * correctly-cased label — `capitalize` would otherwise mangle acronyms and
+   * hyphenated compounds ("VS Code", "First-party").
+   */
+  preserveCase?: boolean;
 }) {
   const dim = disabled || count === 0;
   return (
@@ -36,7 +43,8 @@ export function FilterChip({
       aria-disabled={dim || undefined}
       onClick={onClick}
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-md border capitalize",
+        "inline-flex items-center gap-1.5 rounded-md border",
+        !preserveCase && "capitalize",
         "transition-[transform,background-color,border-color,color] duration-200 ease-out",
         "motion-safe:active:scale-[0.97]",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",

--- a/apps/web/src/lib/facet-label-lib.ts
+++ b/apps/web/src/lib/facet-label-lib.ts
@@ -10,13 +10,22 @@
 
 import type { Platform, SourceStatus, TrustLevel } from "@/types/registry";
 
+// Deliberately a total Record rather than Partial: adding a Platform to the
+// union should fail type-check here until it is given a real label, instead of
+// silently falling through to the humanized slug.
 const PLATFORM_LABELS: Record<Platform, string> = {
   "claude-code": "Claude Code",
   "claude-desktop": "Claude Desktop",
   cursor: "Cursor",
   vscode: "VS Code",
-  cli: "CLI",
+  windsurf: "Windsurf",
+  codex: "Codex",
+  gemini: "Gemini",
   raycast: "Raycast",
+  cli: "CLI",
+  aider: "Aider",
+  zed: "Zed",
+  continue: "Continue",
 };
 
 const TRUST_LABELS: Record<TrustLevel, string> = {
@@ -30,6 +39,7 @@ const SOURCE_LABELS: Record<SourceStatus, string> = {
   "first-party": "First-party",
   "source-backed": "Source-backed",
   external: "External",
+  unverified: "Unverified",
 };
 
 /** Fallback for an id not in a map: de-slug and sentence-case it. */

--- a/apps/web/src/lib/facet-label-lib.ts
+++ b/apps/web/src/lib/facet-label-lib.ts
@@ -1,0 +1,52 @@
+/**
+ * Display labels for the browse sidebar's facet axes.
+ *
+ * The chips used to render raw registry ids and lean on CSS `capitalize` to
+ * tidy them up. That only uppercases the first letter of each word, so slugs
+ * came out as "Claude-Code", "Vscode", "Cli" and "First-Party" — wrong for
+ * acronyms and wrong for hyphenated compounds. These maps carry the real
+ * labels; chips rendering them opt out of `capitalize` via `preserveCase`.
+ */
+
+import type { Platform, SourceStatus, TrustLevel } from "@/types/registry";
+
+const PLATFORM_LABELS: Record<Platform, string> = {
+  "claude-code": "Claude Code",
+  "claude-desktop": "Claude Desktop",
+  cursor: "Cursor",
+  vscode: "VS Code",
+  cli: "CLI",
+  raycast: "Raycast",
+};
+
+const TRUST_LABELS: Record<TrustLevel, string> = {
+  trusted: "Trusted",
+  review: "Review first",
+  limited: "Limited",
+  blocked: "Blocked",
+};
+
+const SOURCE_LABELS: Record<SourceStatus, string> = {
+  "first-party": "First-party",
+  "source-backed": "Source-backed",
+  external: "External",
+};
+
+/** Fallback for an id not in a map: de-slug and sentence-case it. */
+function humanizeFacetId(id: string): string {
+  const spaced = id.replace(/[-_]+/g, " ").trim();
+  if (!spaced) return id;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+export function platformLabel(id: Platform | string): string {
+  return PLATFORM_LABELS[id as Platform] ?? humanizeFacetId(id);
+}
+
+export function trustLabel(id: TrustLevel | string): string {
+  return TRUST_LABELS[id as TrustLevel] ?? humanizeFacetId(id);
+}
+
+export function sourceLabel(id: SourceStatus | string): string {
+  return SOURCE_LABELS[id as SourceStatus] ?? humanizeFacetId(id);
+}

--- a/apps/web/src/lib/safe-error-message-lib.ts
+++ b/apps/web/src/lib/safe-error-message-lib.ts
@@ -1,0 +1,49 @@
+/**
+ * Guards error text before it reaches the UI.
+ *
+ * Route loaders that call server functions get their failures as `Error`s whose
+ * `message` is the raw *response body*: TanStack Start's server-fn client does
+ * `new Error(await response.text())` for any non-OK, non-JSON response. In
+ * production that body is routinely a full HTML document — a Cloudflare WAF
+ * block page on a blocked request, or the `text/html` 500 shell that
+ * `start.ts`/`server.ts` return for an uncaught server error. Rendering
+ * `error.message` verbatim then dumps an entire markup document into the page
+ * as unstyled text (see /jobs/$slug).
+ *
+ * Error components must run messages through `safeErrorMessage` so only short,
+ * human-readable strings are shown and anything else degrades to a fallback.
+ */
+
+/** Longer than this is a payload, not a message meant for a human. */
+const MAX_MESSAGE_LENGTH = 200;
+
+export const GENERIC_ERROR_MESSAGE =
+  "Something went wrong loading this page. Please try again in a moment.";
+
+/**
+ * Markup sniff: `<` immediately followed by a tag-ish character. Prose that
+ * legitimately uses a less-than sign ("limit must be < 100") keeps its space
+ * and is preserved.
+ */
+function looksLikeMarkup(value: string): boolean {
+  return /<[a-z!/?]/i.test(value);
+}
+
+/**
+ * Reduce an arbitrary error message to something safe to render, or fall back.
+ */
+export function safeErrorMessage(
+  message: string | null | undefined,
+  fallback: string = GENERIC_ERROR_MESSAGE,
+): string {
+  if (typeof message !== "string") return fallback;
+
+  // Collapse whitespace so a multi-line body is measured by its real content.
+  const normalized = message.replace(/\s+/g, " ").trim();
+
+  if (!normalized) return fallback;
+  if (normalized.length > MAX_MESSAGE_LENGTH) return fallback;
+  if (looksLikeMarkup(normalized)) return fallback;
+
+  return normalized;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -148,6 +148,13 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
           "The decision layer for Claude Code and AI agent workflows. Search, compare, and inspect trust on MCP servers, skills, hooks, commands, agents, rules, and tools.",
       },
       { name: "theme-color", content: "#f7f5ef" },
+      // Domain-ownership verification token (TalentApp). Public by design — it only
+      // proves we control heyclau.de. Emitted site-wide so the homepage always carries it.
+      {
+        name: "talentapp:project_verification",
+        content:
+          "0f6d1d7b5f35d4b765b2c69292a4c093d9863f98fee4f1037146a764bc5c2411594e641056c97a399869769026667361d5bd18b9f035fc609d1be0cf90138d8f",
+      },
       { property: "og:title", content: "HeyClaude — directory for Claude workflows" },
       {
         property: "og:description",

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -11,6 +11,7 @@ import { useMemo, useCallback } from "react";
 import { toast } from "sonner";
 import { ResourceCard } from "@/components/resource-card";
 import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
+import { platformLabel, sourceLabel, trustLabel } from "@/lib/facet-label-lib";
 import {
   countSearchResults,
   normalizeSearchQuery,
@@ -829,8 +830,9 @@ function Browse() {
                     active={sp.trust === t}
                     onClick={() => onToggleAxisFilter("trust", t)}
                     count={axisCount("trust", t)}
+                    preserveCase
                   >
-                    {t}
+                    {trustLabel(t)}
                   </FilterChip>
                 ))}
               </FilterChipGroup>
@@ -844,8 +846,9 @@ function Browse() {
                     active={sp.source === s}
                     onClick={() => onToggleAxisFilter("source", s)}
                     count={axisCount("source", s)}
+                    preserveCase
                   >
-                    {s}
+                    {sourceLabel(s)}
                   </FilterChip>
                 ))}
               </FilterChipGroup>
@@ -859,8 +862,9 @@ function Browse() {
                     active={sp.platform === p}
                     onClick={() => onToggleAxisFilter("platform", p)}
                     count={axisCount("platform", p)}
+                    preserveCase
                   >
-                    {p}
+                    {platformLabel(p)}
                   </FilterChip>
                 ))}
               </FilterChipGroup>

--- a/apps/web/src/routes/jobs.$slug.tsx
+++ b/apps/web/src/routes/jobs.$slug.tsx
@@ -29,6 +29,7 @@ import type { ReactNode } from "react";
 import type { ErrorComponentProps } from "@tanstack/react-router";
 import type { JobListing } from "@/types/registry";
 import { normalizeJobListing } from "@/lib/job-listing-lib";
+import { safeErrorMessage } from "@/lib/safe-error-message-lib";
 
 const loadJobDetailData = createServerFn({ method: "GET" })
   .inputValidator(z.object({ slug: z.string().min(1) }))
@@ -104,7 +105,9 @@ export const Route = createFileRoute("/jobs/$slug")({
   errorComponent: ({ error, reset }: ErrorComponentProps) => (
     <div className="mx-auto max-w-xl px-4 py-16 text-center">
       <h1 className="font-display text-2xl text-ink">Couldn't load this role</h1>
-      <p className="mt-2 text-sm text-ink-muted">{error.message}</p>
+      <p className="mt-2 text-sm text-ink-muted">
+        {safeErrorMessage(error.message, "We couldn't load this role right now. Please try again.")}
+      </p>
       <button
         onClick={() => {
           trackEvent(jobsErrorRetryAnalyticsEvent(), jobsErrorRetryAnalyticsData("jobs-detail"));

--- a/apps/web/src/routes/jobs.index.tsx
+++ b/apps/web/src/routes/jobs.index.tsx
@@ -128,7 +128,10 @@ export const Route = createFileRoute("/jobs/")({
     <div className="mx-auto max-w-xl px-4 py-16 text-center">
       <h1 className="font-display text-2xl text-ink">Couldn't load jobs</h1>
       <p className="mt-2 text-sm text-ink-muted">
-        {safeErrorMessage(error.message, "We couldn't load the job board right now. Please try again.")}
+        {safeErrorMessage(
+          error.message,
+          "We couldn't load the job board right now. Please try again.",
+        )}
       </p>
       <button
         onClick={() => {

--- a/apps/web/src/routes/jobs.index.tsx
+++ b/apps/web/src/routes/jobs.index.tsx
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { ArrowUpRight, Search, Sparkles, X } from "lucide-react";
 import type { JobListing, JobTier } from "@/types/registry";
 import { normalizeJobListing } from "@/lib/job-listing-lib";
+import { safeErrorMessage } from "@/lib/safe-error-message-lib";
 import { cn } from "@/lib/utils";
 import { JobCard } from "@/components/job-card";
 import {
@@ -126,7 +127,9 @@ export const Route = createFileRoute("/jobs/")({
   errorComponent: ({ error, reset }: ErrorComponentProps) => (
     <div className="mx-auto max-w-xl px-4 py-16 text-center">
       <h1 className="font-display text-2xl text-ink">Couldn't load jobs</h1>
-      <p className="mt-2 text-sm text-ink-muted">{error.message}</p>
+      <p className="mt-2 text-sm text-ink-muted">
+        {safeErrorMessage(error.message, "We couldn't load the job board right now. Please try again.")}
+      </p>
       <button
         onClick={() => {
           trackEvent(jobsErrorRetryAnalyticsEvent(), jobsErrorRetryAnalyticsData("jobs-index"));

--- a/tests/facet-label-lib.test.ts
+++ b/tests/facet-label-lib.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { platformLabel, sourceLabel, trustLabel } from "@/lib/facet-label-lib";
+
+describe("platformLabel", () => {
+  // These are the cases CSS `capitalize` over the raw slug got wrong:
+  // "Vscode", "Cli", "Claude-Code".
+  it("cases acronyms and product names correctly", () => {
+    expect(platformLabel("vscode")).toBe("VS Code");
+    expect(platformLabel("cli")).toBe("CLI");
+    expect(platformLabel("claude-code")).toBe("Claude Code");
+    expect(platformLabel("claude-desktop")).toBe("Claude Desktop");
+    expect(platformLabel("cursor")).toBe("Cursor");
+    expect(platformLabel("raycast")).toBe("Raycast");
+  });
+
+  it("humanizes an unknown id instead of leaking the slug", () => {
+    expect(platformLabel("jetbrains-ide")).toBe("Jetbrains ide");
+  });
+});
+
+describe("trustLabel", () => {
+  it("labels every trust level", () => {
+    expect(trustLabel("trusted")).toBe("Trusted");
+    expect(trustLabel("review")).toBe("Review first");
+    expect(trustLabel("limited")).toBe("Limited");
+    expect(trustLabel("blocked")).toBe("Blocked");
+  });
+});
+
+describe("sourceLabel", () => {
+  it("keeps hyphenated compounds in sentence case", () => {
+    expect(sourceLabel("first-party")).toBe("First-party");
+    expect(sourceLabel("source-backed")).toBe("Source-backed");
+    expect(sourceLabel("external")).toBe("External");
+  });
+});

--- a/tests/facet-label-lib.test.ts
+++ b/tests/facet-label-lib.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { platformLabel, sourceLabel, trustLabel } from "@/lib/facet-label-lib";
+import type { Platform } from "@/types/registry";
 
 describe("platformLabel", () => {
   // These are the cases CSS `capitalize` over the raw slug got wrong:
@@ -12,6 +13,30 @@ describe("platformLabel", () => {
     expect(platformLabel("claude-desktop")).toBe("Claude Desktop");
     expect(platformLabel("cursor")).toBe("Cursor");
     expect(platformLabel("raycast")).toBe("Raycast");
+  });
+
+  it("labels every member of the Platform union", () => {
+    const platforms: Platform[] = [
+      "claude-code",
+      "claude-desktop",
+      "cursor",
+      "vscode",
+      "windsurf",
+      "codex",
+      "gemini",
+      "raycast",
+      "cli",
+      "aider",
+      "zed",
+      "continue",
+    ];
+    for (const p of platforms) {
+      const label = platformLabel(p);
+      expect(label).toBeTruthy();
+      // A label equal to the raw id means the map missed it and the humanize
+      // fallback produced a slug-shaped string.
+      expect(label).not.toBe(p);
+    }
   });
 
   it("humanizes an unknown id instead of leaking the slug", () => {
@@ -33,5 +58,6 @@ describe("sourceLabel", () => {
     expect(sourceLabel("first-party")).toBe("First-party");
     expect(sourceLabel("source-backed")).toBe("Source-backed");
     expect(sourceLabel("external")).toBe("External");
+    expect(sourceLabel("unverified")).toBe("Unverified");
   });
 });

--- a/tests/safe-error-message-lib.test.ts
+++ b/tests/safe-error-message-lib.test.ts
@@ -1,16 +1,23 @@
 import { describe, expect, it } from "vitest";
 
-import { GENERIC_ERROR_MESSAGE, safeErrorMessage } from "@/lib/safe-error-message-lib";
+import {
+  GENERIC_ERROR_MESSAGE,
+  safeErrorMessage,
+} from "@/lib/safe-error-message-lib";
 
 const FALLBACK = "custom fallback";
 
 describe("safeErrorMessage", () => {
   it("passes through a short human-readable message", () => {
-    expect(safeErrorMessage("jobs API returned 503")).toBe("jobs API returned 503");
+    expect(safeErrorMessage("jobs API returned 503")).toBe(
+      "jobs API returned 503",
+    );
   });
 
   it("collapses internal whitespace", () => {
-    expect(safeErrorMessage("  jobs API\n  returned   503  ")).toBe("jobs API returned 503");
+    expect(safeErrorMessage("  jobs API\n  returned   503  ")).toBe(
+      "jobs API returned 503",
+    );
   });
 
   it("falls back on a non-string", () => {
@@ -47,9 +54,13 @@ describe("safeErrorMessage", () => {
   });
 
   it("falls back on markup even when it is short enough to pass the length cap", () => {
-    expect(safeErrorMessage("<html><body>nope</body></html>", FALLBACK)).toBe(FALLBACK);
+    expect(safeErrorMessage("<html><body>nope</body></html>", FALLBACK)).toBe(
+      FALLBACK,
+    );
     expect(safeErrorMessage("<!doctype html>", FALLBACK)).toBe(FALLBACK);
-    expect(safeErrorMessage("<script>alert(1)</script>", FALLBACK)).toBe(FALLBACK);
+    expect(safeErrorMessage("<script>alert(1)</script>", FALLBACK)).toBe(
+      FALLBACK,
+    );
     expect(safeErrorMessage("</div>", FALLBACK)).toBe(FALLBACK);
   });
 

--- a/tests/safe-error-message-lib.test.ts
+++ b/tests/safe-error-message-lib.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { GENERIC_ERROR_MESSAGE, safeErrorMessage } from "@/lib/safe-error-message-lib";
+
+const FALLBACK = "custom fallback";
+
+describe("safeErrorMessage", () => {
+  it("passes through a short human-readable message", () => {
+    expect(safeErrorMessage("jobs API returned 503")).toBe("jobs API returned 503");
+  });
+
+  it("collapses internal whitespace", () => {
+    expect(safeErrorMessage("  jobs API\n  returned   503  ")).toBe("jobs API returned 503");
+  });
+
+  it("falls back on a non-string", () => {
+    expect(safeErrorMessage(undefined, FALLBACK)).toBe(FALLBACK);
+    expect(safeErrorMessage(null, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("falls back on an empty or whitespace-only message", () => {
+    expect(safeErrorMessage("", FALLBACK)).toBe(FALLBACK);
+    expect(safeErrorMessage("   \n\t ", FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("uses the generic message when no fallback is given", () => {
+    expect(safeErrorMessage("", undefined)).toBe(GENERIC_ERROR_MESSAGE);
+  });
+
+  it("falls back on an over-long message", () => {
+    expect(safeErrorMessage("x".repeat(201), FALLBACK)).toBe(FALLBACK);
+    expect(safeErrorMessage("x".repeat(200), FALLBACK)).toBe("x".repeat(200));
+  });
+
+  // The regression this guard exists for: TanStack Start's server-fn client
+  // throws `new Error(await response.text())`, so an edge block page or the
+  // text/html 500 shell arrives as `error.message` and used to be rendered raw.
+  it("falls back on a Cloudflare block page", () => {
+    const blockPage = [
+      "<!DOCTYPE html>",
+      '<html class="no-js" lang="en-US">',
+      "<head><title>Attention Required! | Cloudflare</title></head>",
+      '<body><h1 data-translate="block_headline">Sorry, you have been blocked</h1></body>',
+      "</html>",
+    ].join("\n");
+    expect(safeErrorMessage(blockPage, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("falls back on markup even when it is short enough to pass the length cap", () => {
+    expect(safeErrorMessage("<html><body>nope</body></html>", FALLBACK)).toBe(FALLBACK);
+    expect(safeErrorMessage("<!doctype html>", FALLBACK)).toBe(FALLBACK);
+    expect(safeErrorMessage("<script>alert(1)</script>", FALLBACK)).toBe(FALLBACK);
+    expect(safeErrorMessage("</div>", FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("keeps prose that uses a less-than sign", () => {
+    expect(safeErrorMessage("limit must be < 100")).toBe("limit must be < 100");
+  });
+});


### PR DESCRIPTION
Four independent web fixes reported against the live site. Each is small and self-contained; grouped because they are all header/route chrome and share no logic.

## 1. Navbar search dropdown

**Reported:** the header search "looks awful / doesn't fully extend / things are far too compressed."

The dropdown was pinned to the input with `left-0 right-0`, and the header capped the *entire* right-hand action cluster at `md:max-w-md`. After the icon buttons and the Submit CTA took their ~235px, the input — and therefore the panel — was left around 200px. That is why the scope chips wrapped onto three lines and a result title rendered as `M..`.

- Panel is now anchored to the input's right edge and sized independently: `w-[min(34rem,calc(100vw-2rem))]` with `min-w-full`, so it stays flush with the wide home-hero input and grows leftward out of the narrow header one.
- The width cap moved off the cluster and onto the search slot.
- Result rows gained the `min-w-0` / `shrink-0` they never had — the title had `truncate` (so it collapsed to ~0) while `CategoryPill` and `TrustBadge` were `whitespace-nowrap` and non-shrinking.
- `overflow-x-hidden` on the results list is load-bearing: with only `overflow-y-auto`, CSS computes the other axis to `auto`, which is where the horizontal scrollbar inside the row came from.
- The `<input>` gained `min-w-0`; an input carries a default intrinsic width (~200px) that the row could not shrink below.

**Breakpoints.** While verifying, the header turned out to overflow at 768px on `main` — by **273px** (`scrollWidth` 1026 vs 753), independent of this change. The six primary nav links measure ~420px, which with the logo and actions cannot fit a 768px row. Nav now appears at `lg` instead of `md`; search shows at `sm`, hides at `lg`, returns at `xl`.

Measured after the change — no header overflow at any width:

| viewport | header overflow | nav | search input |
|---|---|---|---|
| 768 | none | hamburger | 296px |
| 1024 | none | visible | hidden |
| 1280 | none | visible | 424px |
| 1440 | none | visible | 448px |

(was ~210px at 1440)

## 2. `/jobs/$slug` dumping raw HTML

**Reported:** a job entry rendered "Couldn't load this role" followed by an entire Cloudflare block page as unstyled text.

`jobs.$slug.tsx:107` rendered `error.message` verbatim. The loader calls a server function, and TanStack Start's server-fn client throws `new Error(await response.text())` for any non-OK, non-JSON response — so an edge block page, or the `text/html` 500 shell that `start.ts`/`server.ts` return for an uncaught server error, arrives as `error.message` and gets printed.

Adds `safeErrorMessage` (markup sniff, 200-char cap, whitespace collapse) and applies it on both jobs routes. `__root.tsx` already used a fixed string; the jobs routes were the only two places in the app rendering a raw error message.

> Note: this fixes the *rendering*. The block itself was a Cloudflare WAF rule firing on the reporter's IP — an edge-config matter, not a code one. Both `/jobs` and `/api/jobs/{slug}` return 200 from outside.

## 3. Browse sidebar facet labels

The sidebar rendered raw registry ids under CSS `capitalize`, giving `Vscode`, `Cli`, `Claude-Code`, `First-Party`. Adds `facet-label-lib` with real labels (`VS Code`, `CLI`, `Claude Code`, `First-party`) plus a `humanizeFacetId` fallback so an unknown id degrades to sentence case instead of leaking a slug.

`FilterChip` gains an opt-in `preserveCase` prop rather than dropping `capitalize` outright — the other three FilterChip callers (`changelog`, `validators`, `trending`) keep their current behavior untouched.

## 4. Domain verification meta tag

Adds the TalentApp `project_verification` token to the root head so the homepage always carries it. Public by design — it only proves control of the domain.

## Validation

```
pnpm test                      795 files / 40,094 tests pass
pnpm build                     green
pnpm validate:content:strict   passes
```

Breakpoint behavior verified in a real browser at 768/1024/1280/1440, before and after, with the `main` baseline measured by stashing the change.
