### PR TITLE
fix(registry): include websiteUrl in entry JSON-LD sameAs

### DIFF
--- a/packages/registry/src/seo-lib.js
+++ b/packages/registry/src/seo-lib.js
@@ -219,7 +219,16 @@ export function buildEntryJsonLd(entry, params = {}) {
     isPartOf: {
       "@id": `${siteUrl.replace(/\/$/, "")}/#website`,
     },
-    sameAs: uniqueValues([entry.documentationUrl, entry.repoUrl]),
+    // websiteUrl leads: schema.org defines sameAs as a URL that "unambiguously
+    // indicates the item's identity", and a project's official site is the
+    // strongest such signal. It was previously only reachable via isBasedOn,
+    // which asserts provenance ("derived from") rather than identity — so the
+    // vendor's own domain was never tied to the entity this page describes.
+    sameAs: uniqueValues([
+      entry.websiteUrl,
+      entry.documentationUrl,
+      entry.repoUrl,
+    ]),
     isBasedOn: sourceUrls.length ? sourceUrls : undefined,
     codeRepository:
       entryType === "SoftwareSourceCode" ? entry.repoUrl : undefined,

--- a/tests/seo-lib.test.ts
+++ b/tests/seo-lib.test.ts
@@ -537,3 +537,55 @@ describe("public wrapper re-exports", () => {
     expect(wrapper.absoluteSiteUrl).toBe(absoluteSiteUrl);
   });
 });
+
+describe("entry JSON-LD entity association", () => {
+  const baseEntry = {
+    category: "mcp",
+    slug: "example-mcp",
+    title: "Example MCP Server",
+    description: "An example.",
+    author: "ExampleAuthor",
+    dateAdded: "2026-01-01",
+  };
+
+  it("puts the official website first in sameAs", () => {
+    const doc = buildEntryJsonLd(
+      {
+        ...baseEntry,
+        websiteUrl: "https://example.com",
+        documentationUrl: "https://docs.example.com",
+        repoUrl: "https://github.com/example/example",
+      },
+      { siteUrl: SITE },
+    );
+
+    // schema.org sameAs is the identity signal. The official site must be in
+    // it, not only in isBasedOn, or nothing ties the page to the vendor's
+    // domain as the same entity.
+    expect(doc.sameAs).toEqual([
+      "https://example.com",
+      "https://docs.example.com",
+      "https://github.com/example/example",
+    ]);
+  });
+
+  it("omits absent URLs rather than emitting holes", () => {
+    const doc = buildEntryJsonLd(
+      { ...baseEntry, repoUrl: "https://github.com/example/example" },
+      { siteUrl: SITE },
+    );
+    expect(doc.sameAs).toEqual(["https://github.com/example/example"]);
+  });
+
+  it("does not duplicate a URL repeated across fields", () => {
+    const doc = buildEntryJsonLd(
+      {
+        ...baseEntry,
+        websiteUrl: "https://example.com",
+        documentationUrl: "https://example.com",
+      },
+      { siteUrl: SITE },
+    );
+    expect(doc.sameAs).toEqual(["https://example.com"]);
+  });
+});


### PR DESCRIPTION
Entry structured data listed only `documentationUrl` and `repoUrl` under `sameAs`. A project's official site reached the markup solely through `isBasedOn`, which asserts *provenance* ("this work derives from that") rather than *identity* — so nothing machine-readable tied an entry to the vendor's own domain as the same entity.

schema.org defines `sameAs` as a URL that "unambiguously indicates the item's identity", and names the official website as a primary example. This puts `entry.websiteUrl` at the head of the list.

## Effect

Regenerated `jsonld-snapshots.json` for `content/mcp/metagraphed-mcp.mdx`:

```diff
- "sameAs": ["https://github.com/JSONbored/metagraphed"]
+ "sameAs": [
+   "https://metagraph.sh",
+   "https://api.metagraph.sh/agent-workflows.md",
+   "https://github.com/JSONbored/metagraphed"
+ ]
```

Applies to every entry that sets `websiteUrl` — 
this is a platform-wide improvement to how we describe the projects we list, not a per-entry tweak.

## Why it matters

Entry pages already emit ~16 dofollow links to a listed project's properties, so this is not about link equity. It is about **entity association**: a crawler reading only the structured data previously learned "HeyClaude has a page about an MCP server by <author>" — with no statement that the thing described *is* the project living at that domain. `sameAs` is the standard mechanism for exactly that, and it feeds entity/knowledge-graph understanding and AI citation metadata.

## Notes

- `uniqueValues` already dedupes, so an entry reusing one URL across `websiteUrl`/`documentationUrl` still emits it once (covered by a test).
- Entries without a `websiteUrl` are byte-identical to before (covered by a test).
- Generated artifacts under `apps/web/public/data/**` are gitignored and rebuilt at deploy, so there is no artifact churn in this diff.

## Validation

```
pnpm exec vitest run tests/seo-lib.test.ts tests/seo-jsonld.test.ts \
  tests/non-ui-branch-matrix.test.ts tests/registry-artifacts.test.ts
  -> 4 files / 114 tests pass
```

Three new cases in `tests/seo-lib.test.ts` cover ordering, omission, and dedupe.