### PR TITLE
fix(mcp): unpin GoodMemory install

### DIFF
--- a/content/mcp/goodmemory-mcp-server.mdx
+++ b/content/mcp/goodmemory-mcp-server.mdx
@@ -20,7 +20,7 @@ repoUrl: "https://github.com/hjqcan/GoodMemory"
 documentationUrl: "https://github.com/hjqcan/GoodMemory/blob/main/docs/GoodMemory-Standalone-MCP-Setup-Guide.md"
 packageUrl: "https://www.npmjs.com/package/goodmemory"
 installable: true
-installCommand: "npm install -g goodmemory@0.7.2"
+installCommand: "npm install -g goodmemory"
 usageSnippet: >-
   Ask Claude to recall relevant project decisions before a task, inspect the
   returned trace, and enable governed writes only after reviewing the memory
@@ -110,7 +110,7 @@ remember pipeline used by the library API.
 Install the published package globally:
 
 ```sh
-npm install -g goodmemory@0.7.2
+npm install -g goodmemory
 ```
 
 Add the standalone server to an MCP client:


### PR DESCRIPTION
## Summary

- remove the GoodMemory version pin from the structured `installCommand`
- remove the same pin from the installation example

## Why

This follows the maintainer suggestion on #5774. `npm install -g goodmemory` resolves npm `latest`, so the directory entry does not become stale after every GoodMemory release. As of this PR, npm `latest` is `0.7.4`.

The separate MCP Registry metadata drift is confirmed: its `versions/latest` endpoint still returns `0.5.1`. A `v0.7.4` manifest passes `mcp-publisher validate`, but republishing is currently blocked on refreshing the expired registry authentication token; this PR does not claim that registry issue is resolved.

## Validation

- `pnpm validate:content:strict` — passed for 1,388 content files; 24 existing warnings are outside this entry
- `git diff --check`

Refs #5774.