### PR TITLE
fix(web): include harness platforms in browse filter

### DIFF
--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -234,7 +234,10 @@ function prepareSearchFilters(filters: SearchFilters = {}): PreparedSearchFilter
 export function matchesSearchFilters(entry: Entry, filters: SearchFilters = {}) {
   const prepared = filters as PreparedSearchFilters;
   if (filters.categories?.length && !filters.categories.includes(entry.category)) return false;
-  if (filters.platforms?.length && !entry.platforms.some((p) => filters.platforms!.includes(p)))
+  if (
+    filters.platforms?.length &&
+    !filters.platforms.some((p) => entry.platforms.includes(p) || entry.harness?.includes(p))
+  )
     return false;
   if (filters.trust?.length && !filters.trust.includes(entry.trust)) return false;
   if (filters.source?.length && !filters.source.includes(entry.source)) return false;

--- a/tests/search-lib-branch-coverage.test.ts
+++ b/tests/search-lib-branch-coverage.test.ts
@@ -117,6 +117,11 @@ describe("search lib branch coverage", () => {
         platforms: ["cursor"],
       }),
     ).toBe(false);
+    expect(
+      matchesSearchFilters(entry({ harness: ["windsurf"], platforms: [] }), {
+        platforms: ["windsurf"],
+      }),
+    ).toBe(true);
   });
 
   it("scores query relevance through title, slug, and sort paths", () => {


### PR DESCRIPTION
# Pull Request

## Summary

- Closes #5753 by matching the browse platform filter against `entry.platforms` or `entry.harness`.
- Adds a regression case for a harness-only Windsurf entry.

## Submission Source

For direct content PRs:

- [ ] This PR changes exactly one `content/<category>/<slug>.mdx` file.
- [ ] The entry includes source/provenance URLs and practical install/use details.
- [ ] `submittedBy` and `submittedByUrl` match the PR author.
- [ ] I did not modify `README.md`, generated registry outputs, downloads, workflows, packages, scripts, or multiple content entries.
- [ ] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.
- [ ] This PR links the issue it resolves, or the no-issue rationale is written in **Notes**.

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

For registry API endpoint PRs:

- [ ] Route handler and central API contract changed together.
- [ ] Origin-check and rate-limit posture is stated below.
- [ ] OpenAPI/source generator impact is stated below; generated artifacts are not hand-edited unless maintainer/internal generation work is explicit.
- [ ] API contract tests were added or updated.
- [ ] Generator reproducibility was checked or the reason it was not checked is listed.

## Schema and Quality Checks

- [ ] Content PR: `pnpm validate:content:strict` passed, or I am relying on CI.
- [x] Platform/code PR: focused validation is listed below.
- [ ] Package artifact PR: `pnpm validate:packages` and `pnpm scan:packages` passed.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)
- [x] Install/use/copy paths are practical and complete.
- [ ] Skill submissions include capability metadata when applicable (`skillType`, `skillLevel`, `verificationStatus`, `verifiedAt`, `retrievalSources`, `testedPlatforms`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `/browse` platform filtering through `matchesSearchFilters` in `apps/web/src/data/search.ts`.
- Expected behavior: `?platform=` now includes entries whose compatibility is declared through `entry.harness`, matching the harness coverage surfaces.
- Important edge cases or invariants: ordinary `entry.platforms` matches still pass; entries with no selected platform in either field still fail.
- Backward compatibility notes: no schema or route changes.
- Screenshots for frontend/page/UI changes:
  - Desktop:
  - Mobile:
- If screenshots do not apply, write `No visual impact` and explain why: No visual impact — this only changes filter inclusion logic.
- Accessibility notes for UI changes: none — no UI rendering changes.
- Focused tests or reason tests are not practical: `tests/search-lib-branch-coverage.test.ts` covers a harness-only Windsurf entry matching a Windsurf platform filter.

## Validation

- [ ] Direct content PR: I did not run generation or commit generated output.
- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [x] I ran the focused checks listed above.
- [ ] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

## Notes

- Linked issue or no-issue rationale: Closes #5753.
- Count check: a harness-only Windsurf regression fixture returns 0 results before this change and 1 after. The current generated catalog has no live harness-only rows, so the generated `windsurf` count remains 181 before and after.
- Validation run locally: `pnpm exec vitest run tests/search-lib-branch-coverage.test.ts`, `pnpm build`, `git diff --check`.
