### PR TITLE
fix(mcp): flag similar-title, same-repo, and same-host duplicates like the web preflight

### DIFF
--- a/packages/mcp/src/submissions-lib.js
+++ b/packages/mcp/src/submissions-lib.js
@@ -839,6 +839,91 @@ function normalizeSubmissionUrlForMatch(value) {
   return url.toString();
 }
 
+const COMMON_SOURCE_HOSTS = new Set([
+  "bitbucket.org",
+  "github.com",
+  "gitlab.com",
+  "marketplace.visualstudio.com",
+  "npmjs.com",
+  "pypi.org",
+  "raw.githubusercontent.com",
+]);
+
+const TITLE_STOP_WORDS = new Set([
+  "and",
+  "for",
+  "mcp",
+  "server",
+  "the",
+  "tool",
+  "with",
+]);
+
+function normalizeComparableSubmissionTitle(value) {
+  return normalizeLower(value).replace(/\s+/g, " ");
+}
+
+function submissionTitleWords(value) {
+  return new Set(
+    normalizeComparableSubmissionTitle(value)
+      .split(/[^a-z0-9]+/i)
+      .map((word) => word.trim())
+      .filter((word) => word.length > 2 && !TITLE_STOP_WORDS.has(word)),
+  );
+}
+
+function isSimilarSubmissionTitle(submittedTitle, entryTitle) {
+  const submitted = normalizeComparableSubmissionTitle(submittedTitle);
+  const existing = normalizeComparableSubmissionTitle(entryTitle);
+  if (!submitted || !existing || submitted === existing) return false;
+  const submittedWords = submissionTitleWords(submitted);
+  const existingWords = submissionTitleWords(existing);
+  if (!submittedWords.size || !existingWords.size) return false;
+  const shared = [...submittedWords].filter((word) => existingWords.has(word));
+  return (
+    shared.length >= 2 &&
+    shared.length / Math.min(submittedWords.size, existingWords.size) >= 0.6
+  );
+}
+
+function githubRepositoryKey(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return "";
+  }
+  if (!["http:", "https:", "git:", "ssh:"].includes(url.protocol)) {
+    return "";
+  }
+  if (url.hostname.toLowerCase().replace(/^www\./, "") !== "github.com") {
+    return "";
+  }
+  const [owner, repoValue] = url.pathname.split("/").filter(Boolean);
+  const repo = repoValue?.replace(/\.git$/i, "") || "";
+  if (!owner || !repo || RESERVED_OWNERS.has(owner.toLowerCase())) return "";
+  if (!/^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/.test(owner)) return "";
+  if (!/^[A-Za-z0-9._-]+$/.test(repo)) return "";
+  return `${owner}/${repo}`.toLowerCase();
+}
+
+function submissionSourceProfile(urls) {
+  const hosts = new Set();
+  const githubRepos = new Set();
+  for (const value of urls) {
+    const url = new URL(value);
+    const host = url.hostname.toLowerCase().replace(/^www\./, "");
+    if (host && !COMMON_SOURCE_HOSTS.has(host)) hosts.add(host);
+    const repo = githubRepositoryKey(value);
+    if (repo) githubRepos.add(repo);
+  }
+  return { hosts, githubRepos };
+}
+
+function setsIntersect(left, right) {
+  return [...left].some((value) => right.has(value));
+}
+
 // Every external-publisher URL field the indexed entry may carry. Includes
 // `downloadUrl`, `websiteUrl`, `githubUrl`, and `trustSignals.sourceUrls` —
 // each is a real entry field today and a duplicate that lives only on one of
@@ -860,6 +945,8 @@ function collectEntrySourceUrls(entry) {
     entry.repoUrl,
     entry.githubUrl,
     entry.sourceUrl,
+    entry.packageUrl,
+    entry.repositoryUrl,
     entry.websiteUrl,
     entry.downloadUrl,
     entry.url,
@@ -920,21 +1007,34 @@ export function searchDuplicateEntries(entries = [], args = {}) {
   const title = normalizeLower(args.title || args.name);
   const brandDomain = normalizeDomain(args.brandDomain);
   const candidateUrls = collectSubmissionCandidateUrls(args);
+  const candidateProfile = submissionSourceProfile(candidateUrls);
 
   const matches = [];
   for (const entry of entries) {
     const reasons = [];
     if (category && normalizeLower(entry.category) !== category) continue;
     if (slug && normalizeLower(entry.slug) === slug) reasons.push("slug");
-    if (title && normalizeLower(entry.title) === title) reasons.push("title");
+    if (title && normalizeLower(entry.title) === title) {
+      reasons.push("title");
+    } else if (title && isSimilarSubmissionTitle(title, entry.title)) {
+      reasons.push("similar_title");
+    }
     if (brandDomain && normalizeDomain(entry.brandDomain) === brandDomain) {
       reasons.push("brand_domain");
     }
+    const entryUrls = collectEntrySourceUrls(entry);
     if (
       candidateUrls.size > 0 &&
-      findOverlappingSourceUrl(collectEntrySourceUrls(entry), candidateUrls)
+      findOverlappingSourceUrl(entryUrls, candidateUrls)
     ) {
       reasons.push("source_url");
+    }
+    const entryProfile = submissionSourceProfile(entryUrls);
+    if (setsIntersect(candidateProfile.githubRepos, entryProfile.githubRepos)) {
+      reasons.push("same_repo");
+    }
+    if (setsIntersect(candidateProfile.hosts, entryProfile.hosts)) {
+      reasons.push("same_host");
     }
 
     if (!reasons.length) continue;

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -2261,12 +2261,12 @@ describe("HeyClaude read-only MCP helpers", () => {
     expect(duplicate).toMatchObject({
       ok: true,
       count: expect.any(Number),
-      matches: [
+      matches: expect.arrayContaining([
         expect.objectContaining({
           key: `${skill.category}:${skill.slug}`,
           reasons: expect.arrayContaining(["slug", "title"]),
         }),
-      ],
+      ]),
     });
   });
 

--- a/tests/mcp-submission-duplicate-urls.test.ts
+++ b/tests/mcp-submission-duplicate-urls.test.ts
@@ -22,6 +22,54 @@ function entry(overrides: RegistryEntry = {}): RegistryEntry {
 }
 
 describe("searchDuplicateEntries source-URL matching", () => {
+  it("flags fuzzy similar-title matches like the web preflight", () => {
+    const result = searchDuplicateEntries(
+      [entry({ title: "Browser Automation MCP" })],
+      { title: "Browser Automation Server" },
+    );
+    expect(result.count).toBe(1);
+    expect(
+      (result.matches as Array<{ reasons: string[] }>)[0].reasons,
+    ).toContain("similar_title");
+  });
+
+  it("flags URLs that point to the same GitHub repository", () => {
+    const result = searchDuplicateEntries(
+      [
+        entry({
+          documentationUrl: "",
+          repoUrl: "",
+          githubUrl: "https://github.com/example/browser-automation",
+        }),
+      ],
+      {
+        githubUrl:
+          "https://github.com/example/browser-automation/tree/main/packages/mcp",
+      },
+    );
+    expect(result.count).toBe(1);
+    expect(
+      (result.matches as Array<{ reasons: string[] }>)[0].reasons,
+    ).toContain("same_repo");
+  });
+
+  it("flags different URLs on the same non-generic source host", () => {
+    const result = searchDuplicateEntries(
+      [
+        entry({
+          documentationUrl: "",
+          repoUrl: "",
+          docsUrl: "https://docs.vendor.example.com/install",
+        }),
+      ],
+      { docsUrl: "https://docs.vendor.example.com/guide" },
+    );
+    expect(result.count).toBe(1);
+    expect(
+      (result.matches as Array<{ reasons: string[] }>)[0].reasons,
+    ).toContain("same_host");
+  });
+
   it("matches a trailing-slash variant against an indexed entry's repoUrl", () => {
     const result = searchDuplicateEntries([entry()], {
       sourceUrl: "https://github.com/domdomegg/airtable-mcp-server/",
@@ -101,6 +149,40 @@ describe("searchDuplicateEntries source-URL matching", () => {
       { sourceUrl: "https://www.airtable-mcp.example" },
     );
     expect(result.count).toBe(1);
+  });
+
+  it("matches when the entry's matching URL lives only on packageUrl", () => {
+    const result = searchDuplicateEntries(
+      [
+        entry({
+          documentationUrl: "",
+          repoUrl: "",
+          packageUrl: "https://www.npmjs.com/package/browser-automation-mcp",
+        }),
+      ],
+      { sourceUrl: "https://www.npmjs.com/package/browser-automation-mcp/" },
+    );
+    expect(result.count).toBe(1);
+    expect(
+      (result.matches as Array<{ reasons: string[] }>)[0].reasons,
+    ).toContain("source_url");
+  });
+
+  it("matches when the entry's matching URL lives only on repositoryUrl", () => {
+    const result = searchDuplicateEntries(
+      [
+        entry({
+          documentationUrl: "",
+          repoUrl: "",
+          repositoryUrl: "https://github.com/example/browser-automation-mcp",
+        }),
+      ],
+      { sourceUrl: "https://github.com/example/browser-automation-mcp/" },
+    );
+    expect(result.count).toBe(1);
+    expect(
+      (result.matches as Array<{ reasons: string[] }>)[0].reasons,
+    ).toContain("source_url");
   });
 
   it("matches when the entry's matching URL lives only in trustSignals.sourceUrls", () => {

--- a/tests/mcp-submissions-review-lib.test.ts
+++ b/tests/mcp-submissions-review-lib.test.ts
@@ -80,7 +80,7 @@ describe("submissions-lib duplicate search matching", () => {
         category: "mcp",
         sourceUrls: ["https://github.com/x/y"],
       }).matches[0].reasons,
-    ).toEqual(["source_url"]);
+    ).toEqual(["source_url", "same_repo"]);
   });
 
   it("skips entries in other categories and reports when nothing matches", () => {


### PR DESCRIPTION
## Summary

- `submission.duplicates` now flags the same duplicate shapes the web submission gate flags:
  - **similar_title** — fuzzy word-overlap matching (stop-word filtered, shared/min-set ratio >= 0.6), in the spirit of the web preflight's `isSimilarSubmissionTitle`
  - **same_repo** — GitHub `owner/repo` equality across source URLs (tree/blob/deep links resolve to their repo)
  - **same_host** — non-generic hostname overlap across source URLs (github/npm/pypi etc. excluded)
- `collectEntrySourceUrls` now also collects `entry.packageUrl` and `entry.repositoryUrl`
- Existing exact slug / title / source_url / brand_domain matching behavior is unchanged

Closes #5771

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools: `packages/mcp/src/submissions-lib.js` (`searchDuplicateEntries`, `collectEntrySourceUrls`, plus new helpers).
- [x] This PR links the issue it resolves: #5771.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added.

## Quality Evidence

- Changed routes/components/endpoints/tools: MCP tool `submission.duplicates` (pure helper functions, no network).
- Expected behavior: submissions whose title is a fuzzy match of an existing entry, or whose URLs share a GitHub repo or non-generic host with an existing entry, are now reported as duplicates with the respective reason — matching what the private web gate already blocks.
- Important edge cases or invariants: generic hosts (github.com, npmjs.com, pypi.org, …) never trigger `same_host`; `same_repo` requires a valid GitHub owner/repo and ignores reserved owners; exact-title match still wins over fuzzy (`similar_title` is only checked when titles differ).
- Backward compatibility notes: existing reasons (`slug`, `title`, `brand_domain`, `source_url`) unchanged; new reasons are additive.
- Screenshots: No visual impact — server-side helper logic only.
- Focused tests: `tests/mcp-submission-duplicate-urls.test.ts` extended with 5 new cases (similar_title, same_repo, same_host, packageUrl collection, repositoryUrl collection).

## Validation

- [x] Platform/code PR: `pnpm --filter @heyclaude/mcp test` passed locally (75/75, including the 5 new regression tests).
- [x] Red-green check performed: with the implementation change stashed, the 5 new tests fail; with it restored, all 22 tests in the focused file pass.

## Notes

- Linked issue: #5771 (help wanted). Acceptance criteria from the issue are covered 1:1 by the four new match types and the URL collection extension.
- Follow-up (not in scope): the thresholds (0.6 ratio, stop-word list) were chosen to mirror the web preflight's intent; happy to tune if maintainers prefer different constants.